### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,8 @@ FastMCP 会自动暴露一个名为 `get_popular` 的工具：
 ## 📄 License
 
 MIT License.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/xspadex-bilibili-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/xspadex-bilibili-mcp).